### PR TITLE
Fix CLI argument splitting issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           mappings: 'example-mapping-directory'
           files: 'example-files-directory'
-          command: 'node example.test.js'
+          command: 'npm run test:example'
           verbose: true
       - name: Get the WireMock standard output
         run: echo "${{ steps.setup-wiremock.outputs.wiremock-stdout }}"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ References:
 
 **Required** Command to run tests
 
+Note: a child process is spawned and run in a shell with this command, so **do not** run unvalidated commands.
+
 Example: `'npm test --testNamePattern=MyApiTests'`
 
 ### `http-port`
@@ -64,9 +66,11 @@ jobs:
         uses: williamhaw/setup-wiremock-action@v0.1.2
         id: setup-wiremock
         with:
+          http-port: '8080'
           mappings: 'example-mapping-directory'
           files: 'example-files-directory'
           command: 'node example.test.js'
+          verbose: false
       - name: Get the WireMock standard output
         run: echo "${{ steps.setup-wiremock.outputs.wiremock-stdout }}"
 ```

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ References:
 
 **Required** Command to run tests
 
-Note: Only verbose flags are currently supported. (Flags that start with `--`)
-
 Example: `'npm test --testNamePattern=MyApiTests'`
 
 ### `http-port`

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const getInputs = () => {
     filesPath: filesPath,
     httpPort: httpPort,
     testCommandString: testCommandString,
-    isVerboseLogging: isVerboseLogging
+    isVerboseLogging: isVerboseLogging,
   };
 };
 
@@ -66,32 +66,32 @@ const copyStubs = (inputMappingsPath, inputFilesPath) => {
   return {
     currentWorkingDirectory: cwd,
     wiremockMappingsPath: wiremockMappingsPath,
-    wiremockFilesPath: wiremockFilesPath
+    wiremockFilesPath: wiremockFilesPath,
   };
 };
 
 const startWireMock = (wiremockPath, isVerboseLogging) => {
   const options = {
     cwd: cwd,
-    detached: true
+    detached: true,
   };
   let args = ["-jar", wiremockPath];
   if (isVerboseLogging) {
     args.push("--verbose");
   }
   const wiremockProcess = cp.spawn("java", args, options);
-  wiremockProcess.stdout.on("data", data => {
+  wiremockProcess.stdout.on("data", (data) => {
     wiremockStdOut.write(data.toString("utf8"));
   });
   return wiremockProcess;
 };
 
-const isWireMockRunning = async httpPort => {
+const isWireMockRunning = async (httpPort) => {
   try {
     const retry = {
       retry: {
-        limit: 3
-      }
+        limit: 3,
+      },
     };
     const response = await got(
       `http://localhost:${httpPort}/__wiremock_ping`,
@@ -104,7 +104,7 @@ const isWireMockRunning = async httpPort => {
 };
 
 //run tests from CLI (command to run tests to be given through action parameter)
-const runAPITests = commandString => {
+const runAPITests = (commandString) => {
   const command = minimist(commandString);
   const executable = command._[0];
   const executableInput = command._.slice(1);
@@ -118,11 +118,14 @@ const runAPITests = commandString => {
 
   console.log(`Running executable: ${executable} with args: ${args}`);
 
-  const testProcess = cp.spawnSync(executable, args, { stdio: "inherit" });
+  const testProcess = cp.spawnSync(commandString, args, {
+    stdio: "inherit",
+    shell: true,
+  });
   return testProcess.status === 0;
 };
 
-const shutdownWiremock = async wiremockProcess => {
+const shutdownWiremock = async (wiremockProcess) => {
   wiremockProcess.kill();
   await wait(1000); //kill is asynchronous and there is no killSync method. Required to wait for remaining stdout to be produced.
   wiremockStdOut.end();
@@ -140,7 +143,7 @@ const cleanupFiles = (wiremockMappingsPath, wiremockFilesPath) => {
 };
 
 const wait = (duration, ...args) =>
-  new Promise(resolve => {
+  new Promise((resolve) => {
     setTimeout(resolve, duration, ...args);
   });
 
@@ -155,7 +158,7 @@ Main logic starts
       filesPath,
       httpPort,
       testCommandString,
-      isVerboseLogging
+      isVerboseLogging,
     } = getInputs();
 
     const wiremockPath = await installWiremockFromToolCache();
@@ -196,7 +199,7 @@ Main logic starts
       process.exit(1);
     }
   }
-})().catch(error => {
+})().catch((error) => {
   core.setFailed(error.message);
   process.exit(1);
 });

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const fs = require("fs-extra");
 const cp = require("child_process");
 const process = require("process");
 const got = require("got");
-const minimist = require("minimist-string");
 
 const wiremockVersion = "2.26.3";
 const wiremockStdOutPath = "out.log";

--- a/index.js
+++ b/index.js
@@ -105,7 +105,6 @@ const isWireMockRunning = async httpPort => {
 
 //run tests from CLI (command to run tests to be given through action parameter)
 const runAPITests = commandString => {
-  console.log(`Command received: ${commandString}`);
   const command = minimist(commandString);
   const executable = command._[0];
   const executableInput = command._.slice(1);
@@ -116,6 +115,8 @@ const runAPITests = commandString => {
   args.push(
     Object.entries(command).flatMap(([key, value]) => [`--${key}`, value]) //only support verbose flags for now
   );
+
+  console.log(`Running executable: ${executable} with args: ${args}`);
 
   const testProcess = cp.spawnSync(executable, args, { stdio: "inherit" });
   return testProcess.status === 0;

--- a/index.js
+++ b/index.js
@@ -105,20 +105,8 @@ const isWireMockRunning = async (httpPort) => {
 
 //run tests from CLI (command to run tests to be given through action parameter)
 const runAPITests = (commandString) => {
-  const command = minimist(commandString);
-  const executable = command._[0];
-  const executableInput = command._.slice(1);
-
-  var args = [];
-  args.push(executableInput);
-
-  args.push(
-    Object.entries(command).flatMap(([key, value]) => [`--${key}`, value]) //only support verbose flags for now
-  );
-
-  console.log(`Running executable: ${executable} with args: ${args}`);
-
-  const testProcess = cp.spawnSync(commandString, args, {
+  console.log(`Running command: ${commandString}`);
+  const testProcess = cp.spawnSync(commandString, {
     stdio: "inherit",
     shell: true,
   });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Setup a standalone Wiremock process with stubs defined in JSON files",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test:example": "node example.test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "@actions/core": "^1.9.1",
     "@actions/tool-cache": "^1.3.3",
     "fs-extra": "^9.0.0",
-    "got": "^10.7.0",
-    "minimist-string": "^1.0.2"
+    "got": "^10.7.0"
   },
   "devDependencies": {
     "prettier": "2.0.2",


### PR DESCRIPTION
# Changes
- Add test:example npm script 
- Use it in main.yml

#Why Changes Are Needed
https://github.com/williamhaw/setup-wiremock-action/issues/8